### PR TITLE
Add Lato font

### DIFF
--- a/scudcloud-0.9/debian/changelog
+++ b/scudcloud-0.9/debian/changelog
@@ -1,3 +1,9 @@
+scudcloud (0.9-20) trusty; urgency=low
+
+  * Adding lato font (#11)
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Sat, 28 Feb 2015 10:22:36 -0300
+
 scudcloud (0.9-19) trusty; urgency=low
 
   * Adding spell checker (#9)

--- a/scudcloud-0.9/debian/control
+++ b/scudcloud-0.9/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/raelgc/scudcloud
 
 Package: scudcloud
 Architecture: all
-Depends: ${misc:Depends}, python3, python3-pyqt4, python3-gi, libunity9, libqtwebkit-qupzillaplugins
+Depends: ${misc:Depends}, python3, python3-pyqt4, python3-gi, libunity9, libqtwebkit-qupzillaplugins, fonts-lato
 Description: ScudCloud is a non official desktop client for Slack
  ScudCloud is a non official desktop client for Slack.
  Slack (http://slack.com) is a platform for team communication.


### PR DESCRIPTION
Slack uses `Lato` for `sans-serif` family, not installed by default and not rendered by current `webkit` version included in Ubuntu.
