### PR TITLE
crash on ubuntu 14.04

### DIFF
--- a/scudcloud-1.0/debian/control
+++ b/scudcloud-1.0/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/raelgc/scudcloud
 
 Package: scudcloud
 Architecture: all
-Depends: ${misc:Depends}, python3, python3-pyqt4, python3-gi, python3-dbus, libunity9, libqtwebkit-qupzillaplugins, fonts-lato
+Depends: ${misc:Depends}, python3, python3-pyqt4, python3-gi, python3-dbus, libunity9, gir1.2-unity-5.0, libqtwebkit-qupzillaplugins, fonts-lato
 Description: ScudCloud is a non official desktop client for Slack
  ScudCloud is a non official desktop client for Slack.
  Slack (http://slack.com) is a platform for team communication.


### PR DESCRIPTION
Hi,

I am trying to install scudcloud on Ubuntu 14.04 LTS freshly installed, but it does not start, please see the error below.

anything I can do to help ? Looking forward to have a linux slack app :)

Cheers,

```
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 2135, in _find_spec
AttributeError: 'DynamicImporter' object has no attribute 'find_spec'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/scudcloud", line 6, in <module>
    from scudcloud import ScudCloud
  File "/opt/scudcloud/lib/scudcloud.py", line 10, in <module>
    from gi.repository import Unity, GObject, Dbusmenu
  File "/usr/lib/python3/dist-packages/gi/importer.py", line 53, in find_module
    'introspection typelib not found' % namespace)
ImportError: cannot import name Unity, introspection typelib not found
Error in sys.excepthook:
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/apport_python_hook.py", line 138, in apport_excepthook
    os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o640), 'wb') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/var/crash/_opt_scudcloud_scudcloud.10104.crash'

Original exception was:
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 2135, in _find_spec
AttributeError: 'DynamicImporter' object has no attribute 'find_spec'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/scudcloud", line 6, in <module>
    from scudcloud import ScudCloud
  File "/opt/scudcloud/lib/scudcloud.py", line 10, in <module>
    from gi.repository import Unity, GObject, Dbusmenu
  File "/usr/lib/python3/dist-packages/gi/importer.py", line 53, in find_module
    'introspection typelib not found' % namespace)
ImportError: cannot import name Unity, introspection typelib not found
```
