### PR TITLE
show number of unread chats on tray icon (feature request)

### DIFF
--- a/scudcloud-1.0/debian/changelog
+++ b/scudcloud-1.0/debian/changelog
@@ -1,3 +1,9 @@
+scudcloud (1.0-14) trusty; urgency=low
+
+  * Adding count to systray (#16) 
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Thu, 12 Mar 2015 10:33:49 -0300
+
 scudcloud (1.0-13) trusty; urgency=low
 
   * Adding gir1.2-unity-5.0 as dependency (#24)

--- a/scudcloud-1.0/debian/control
+++ b/scudcloud-1.0/debian/control
@@ -2,7 +2,7 @@ Source: scudcloud
 Section: utils
 Priority: optional
 Maintainer: Rael Gugelmin Cunha <rael.gc@gmail.com>
-Build-Depends: debhelper (>= 9), python3 | python3-all | python3-dev | python3-all-dev
+Build-Depends: debhelper (>= 9)
 Standards-Version: 3.9.5
 Homepage: https://github.com/raelgc/scudcloud
 

--- a/scudcloud-1.0/debian/install
+++ b/scudcloud-1.0/debian/install
@@ -3,10 +3,6 @@ LICENSE opt/scudcloud
 resources/* opt/scudcloud/resources
 scudcloud opt/scudcloud
 scudcloud.desktop usr/share/applications
-systray/mono-dark/scudcloud.svg usr/share/icons/ubuntu-mono-dark/scalable/apps
-systray/mono-dark/scudcloud-attention.svg usr/share/icons/ubuntu-dark-light/scalable/apps 
-systray/mono-light/scudcloud.svg usr/share/icons/ubuntu-mono-light/scalable/apps
-systray/mono-light/scudcloud-attention.svg usr/share/icons/ubuntu-mono-light/scalable/apps
-systray/hicolor/scudcloud.svg usr/share/icons/hicolor/scalable/apps
-systray/hicolor/scudcloud-attention.svg usr/share/icons/hicolor/scalable/apps
-
+systray/mono-dark/* usr/share/icons/ubuntu-mono-dark/scalable/apps
+systray/mono-light/* usr/share/icons/ubuntu-mono-light/scalable/apps
+systray/hicolor/* usr/share/icons/hicolor/scalable/apps

--- a/scudcloud-1.0/lib/scudcloud.py
+++ b/scudcloud-1.0/lib/scudcloud.py
@@ -21,7 +21,6 @@ class ScudCloud(QtGui.QMainWindow):
     SIGNIN_URL = "https://slack.com/signin"
     debug = False
     forceClose = False
-    urgent = False
     messages = 0
 
     def __init__(self, parent=None):
@@ -172,7 +171,6 @@ class ScudCloud(QtGui.QMainWindow):
     def focusInEvent(self, event):
         self.launcher.set_property("urgent", False)
         self.tray.stopAlert()
-        self.urgent = False
 
     def titleChanged(self):
         self.setWindowTitle(self.current().title())
@@ -214,10 +212,9 @@ class ScudCloud(QtGui.QMainWindow):
         self.alert()
 
     def alert(self):
-        if not self.isActiveWindow() and not self.urgent:
+        if not self.isActiveWindow():
             self.launcher.set_property("urgent", True)
             self.tray.alert()
-            self.urgent = True
 
     def count(self):
         total = 0
@@ -225,9 +222,11 @@ class ScudCloud(QtGui.QMainWindow):
             total+=self.stackedWidget.widget(i).messages
         if total > self.messages:
             self.alert()
-        elif 0 == total:
+        if 0 == total:
             self.launcher.set_property("count_visible", False)
+            self.tray.setCounter(0)
         else:
+            self.tray.setCounter(total)
             self.launcher.set_property("count", total)
             self.launcher.set_property("count_visible", True)
         self.messages = total

--- a/scudcloud-1.0/lib/systray.py
+++ b/scudcloud-1.0/lib/systray.py
@@ -1,6 +1,9 @@
 from PyQt4 import QtCore, QtGui
 
 class Systray(QtGui.QSystemTrayIcon):
+
+    urgent = False
+
     def __init__(self, window):
         super(Systray, self).__init__(QtGui.QIcon.fromTheme("scudcloud"), window)
         self.connect(self, QtCore.SIGNAL("activated(QSystemTrayIcon::ActivationReason)"), self.activatedEvent)
@@ -16,10 +19,24 @@ class Systray(QtGui.QSystemTrayIcon):
         self.setContextMenu(self.menu)
 
     def alert(self):
-        self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention"))
+        if not self.urgent:
+            self.urgent = True
+            self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention"))
 
     def stopAlert(self):
+        self.urgent = False
         self.setIcon(QtGui.QIcon.fromTheme("scudcloud"))
+
+    def setCounter(self, i):
+        if 0 == i:
+            if True == self.urgent:
+                self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention"))
+            else:
+                self.setIcon(QtGui.QIcon.fromTheme("scudcloud"))
+        elif i > 0 and i < 10:
+            self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention-"+str(i)))
+        elif i > 9:
+            self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention-9-plus"))
 
     def restore(self):
         self.window.show()

--- a/scudcloud-1.0/systray/hicolor/scudcloud-attention-1.svg
+++ b/scudcloud-1.0/systray/hicolor/scudcloud-attention-1.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/hicolor/scudcloud-attention-2.svg
+++ b/scudcloud-1.0/systray/hicolor/scudcloud-attention-2.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-1.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/hicolor/scudcloud-attention-3.svg
+++ b/scudcloud-1.0/systray/hicolor/scudcloud-attention-3.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-2.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">3</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/hicolor/scudcloud-attention-4.svg
+++ b/scudcloud-1.0/systray/hicolor/scudcloud-attention-4.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-3.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">4</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/hicolor/scudcloud-attention-5.svg
+++ b/scudcloud-1.0/systray/hicolor/scudcloud-attention-5.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-4.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">5</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/hicolor/scudcloud-attention-6.svg
+++ b/scudcloud-1.0/systray/hicolor/scudcloud-attention-6.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-5.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">6</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/hicolor/scudcloud-attention-7.svg
+++ b/scudcloud-1.0/systray/hicolor/scudcloud-attention-7.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-6.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">7</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/hicolor/scudcloud-attention-8.svg
+++ b/scudcloud-1.0/systray/hicolor/scudcloud-attention-8.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-7.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">8</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/hicolor/scudcloud-attention-9-plus.svg
+++ b/scudcloud-1.0/systray/hicolor/scudcloud-attention-9-plus.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-9.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="16.155013"
+     inkscape:cy="5.2666349"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="8.6446733"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="8.6446733"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">9<tspan
+   style="font-size:10px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold"
+   id="tspan3934" /></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8.86672974px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="13.193736"
+       y="17.333946"
+       id="text3936"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3938"
+         x="13.193736"
+         y="17.333946"
+         style="font-size:8.86672974px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Sans;-inkscape-font-specification:Sans Bold">+</tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/hicolor/scudcloud-attention-9.svg
+++ b/scudcloud-1.0/systray/hicolor/scudcloud-attention-9.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-8.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">9</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-dark/scudcloud-attention-1.svg
+++ b/scudcloud-1.0/systray/mono-dark/scudcloud-attention-1.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-dark/scudcloud-attention-2.svg
+++ b/scudcloud-1.0/systray/mono-dark/scudcloud-attention-2.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-1.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-dark/scudcloud-attention-3.svg
+++ b/scudcloud-1.0/systray/mono-dark/scudcloud-attention-3.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-2.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">3</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-dark/scudcloud-attention-4.svg
+++ b/scudcloud-1.0/systray/mono-dark/scudcloud-attention-4.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-3.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">4</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-dark/scudcloud-attention-5.svg
+++ b/scudcloud-1.0/systray/mono-dark/scudcloud-attention-5.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-4.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">5</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-dark/scudcloud-attention-6.svg
+++ b/scudcloud-1.0/systray/mono-dark/scudcloud-attention-6.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-5.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">6</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-dark/scudcloud-attention-7.svg
+++ b/scudcloud-1.0/systray/mono-dark/scudcloud-attention-7.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-6.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">7</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-dark/scudcloud-attention-8.svg
+++ b/scudcloud-1.0/systray/mono-dark/scudcloud-attention-8.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-7.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">8</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-dark/scudcloud-attention-9-plus.svg
+++ b/scudcloud-1.0/systray/mono-dark/scudcloud-attention-9-plus.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-9.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="16.155013"
+     inkscape:cy="5.2666349"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="8.6446733"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="8.6446733"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">9<tspan
+   style="font-size:10px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold"
+   id="tspan3934" /></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8.86672974px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="13.193736"
+       y="17.333946"
+       id="text3936"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3938"
+         x="13.193736"
+         y="17.333946"
+         style="font-size:8.86672974px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Sans;-inkscape-font-specification:Sans Bold">+</tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-dark/scudcloud-attention-9.svg
+++ b/scudcloud-1.0/systray/mono-dark/scudcloud-attention-9.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-8.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">9</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-light/scudcloud-attention-1.svg
+++ b/scudcloud-1.0/systray/mono-light/scudcloud-attention-1.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">1</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-light/scudcloud-attention-2.svg
+++ b/scudcloud-1.0/systray/mono-light/scudcloud-attention-2.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-1.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">2</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-light/scudcloud-attention-3.svg
+++ b/scudcloud-1.0/systray/mono-light/scudcloud-attention-3.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-2.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">3</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-light/scudcloud-attention-4.svg
+++ b/scudcloud-1.0/systray/mono-light/scudcloud-attention-4.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-3.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">4</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-light/scudcloud-attention-5.svg
+++ b/scudcloud-1.0/systray/mono-light/scudcloud-attention-5.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-4.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">5</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-light/scudcloud-attention-6.svg
+++ b/scudcloud-1.0/systray/mono-light/scudcloud-attention-6.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-5.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">6</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-light/scudcloud-attention-7.svg
+++ b/scudcloud-1.0/systray/mono-light/scudcloud-attention-7.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-6.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">7</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-light/scudcloud-attention-8.svg
+++ b/scudcloud-1.0/systray/mono-light/scudcloud-attention-8.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-7.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">8</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-light/scudcloud-attention-9-plus.svg
+++ b/scudcloud-1.0/systray/mono-light/scudcloud-attention-9-plus.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-9.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="16.155013"
+     inkscape:cy="5.2666349"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="8.6446733"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="8.6446733"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">9<tspan
+   style="font-size:10px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold"
+   id="tspan3934" /></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:8.86672974px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="13.193736"
+       y="17.333946"
+       id="text3936"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3938"
+         x="13.193736"
+         y="17.333946"
+         style="font-size:8.86672974px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Sans;-inkscape-font-specification:Sans Bold">+</tspan></text>
+  </g>
+</svg>

--- a/scudcloud-1.0/systray/mono-light/scudcloud-attention-9.svg
+++ b/scudcloud-1.0/systray/mono-light/scudcloud-attention-9.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="scudcloud-attention-8.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="12.771242"
+     inkscape:cy="11.54065"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer3"
+     showgrid="false"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="1973"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Layer"
+     style="display:inline">
+    <path
+       style="fill:#19b6ed;fill-opacity:1"
+       d="M 4.3346336,20.546579 C 4.1752471,20.288701 4.3786968,19.480704 4.7676666,18.826787 4.942191,18.533323 5.1119538,18.020735 5.1449177,17.687653 5.2045261,17.085238 5.1995267,17.080845 4.2268468,16.877926 2.595899,16.537714 1.4961388,15.723451 0.7348189,14.292367 0.23035568,13.344049 0.26377909,10.555065 0.79143696,9.5679953 1.268516,8.6755755 2.3349147,7.6912417 3.1612347,7.3806343 4.5522491,6.8576729 4.5824856,6.8366392 4.5824856,6.389889 c 0,-0.9485335 0.7540879,-2.4770789 1.6776874,-3.4006891 1.1487817,-1.1487861 2.4597211,-1.6780863 4.152572,-1.6766457 2.798852,0 4.645146,1.2151287 5.661675,3.7190762 0.390595,0.962076 0.427393,0.9957154 1.215854,1.1111847 2.536927,0.3716195 4.175757,2.2818686 4.321913,5.0377159 0.09447,1.781094 -0.345472,3.089864 -1.40598,4.18261 -1.331756,1.372306 -1.822569,1.495266 -6.372198,1.596471 l -3.9960334,0.08895 -0.2210699,0.444517 c -0.3984779,0.801303 -1.6208975,2.079603 -2.4576544,2.569934 -0.8878009,0.520296 -2.618772,0.816642 -2.8246177,0.483558 z M 17.098484,13.714443 c 0.143158,-0.226977 0.143157,-0.395389 -4e-6,-0.622368 -0.16419,-0.260326 -0.483837,-0.313632 -1.955106,-0.32631 -1.798499,-0.01512 -2.20337,0.09919 -2.20337,0.623666 0,0.555591 0.352213,0.661264 2.162514,0.648657 1.512028,-0.01007 1.831059,-0.06195 1.995966,-0.323645 z"
+       id="path4337"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="unread circle">
+    <path
+       sodipodi:type="arc"
+       style="fill:#ff0000;fill-opacity:1;stroke:none"
+       id="path3752"
+       sodipodi:cx="13.90625"
+       sodipodi:cy="14.21875"
+       sodipodi:rx="6.84375"
+       sodipodi:ry="6.84375"
+       d="m 20.75,14.21875 a 6.84375,6.84375 0 1 1 -13.6875,0 6.84375,6.84375 0 1 1 13.6875,0 z" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="unread number">
+    <text
+       xml:space="preserve"
+       style="font-size:27.72813606px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
+       x="11.326812"
+       y="17.625"
+       id="text3755"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3757"
+         x="11.326812"
+         y="17.625"
+         style="font-size:8.97680759px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;font-family:Segoe UI;-inkscape-font-specification:Segoe UI Bold">9</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+       x="-8.5736694"
+       y="0.035495557"
+       id="text3759"
+       sodipodi:linespacing="125%"><tspan
+         sodipodi:role="line"
+         id="tspan3761"></tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
I'm using ScudCloud on LinuxMint and like the tray icon which appears when I enable Close to Tray feature. What I miss is the number of unread chats on it.

It should show:
number of "direct messages" chats that have unread messages in them
number of channels and private groups with unread messages if notifications are enabled for them
