### PR TITLE
Auto-detection of Unity and Dbusmenu (#27)

### DIFF
--- a/scudcloud-1.0/debian/control
+++ b/scudcloud-1.0/debian/control
@@ -8,8 +8,8 @@ Homepage: https://github.com/raelgc/scudcloud
 
 Package: scudcloud
 Architecture: all
-Depends: ${misc:Depends}, python3, python3-pyqt4, python3-gi, python3-dbus
-Recommends: gir1.2-unity-5.0, libqtwebkit-qupzillaplugins, fonts-lato
+Depends: ${misc:Depends}, python3, python3-pyqt4, python3-dbus
+Recommends: python3-gi, gir1.2-unity-5.0, libqtwebkit-qupzillaplugins, fonts-lato
 Description: ScudCloud is a non official desktop client for Slack
  ScudCloud is a non official desktop client for Slack.
  Slack (http://slack.com) is a platform for team communication.

--- a/scudcloud-1.0/debian/control
+++ b/scudcloud-1.0/debian/control
@@ -8,7 +8,8 @@ Homepage: https://github.com/raelgc/scudcloud
 
 Package: scudcloud
 Architecture: all
-Depends: ${misc:Depends}, python3, python3-pyqt4, python3-gi, python3-dbus, libunity9, gir1.2-unity-5.0, libqtwebkit-qupzillaplugins, fonts-lato
+Depends: ${misc:Depends}, python3, python3-pyqt4, python3-gi, python3-dbus, libunity9, gir1.2-unity-5.0
+Recommends: libqtwebkit-qupzillaplugins, fonts-lato
 Description: ScudCloud is a non official desktop client for Slack
  ScudCloud is a non official desktop client for Slack.
  Slack (http://slack.com) is a platform for team communication.

--- a/scudcloud-1.0/debian/control
+++ b/scudcloud-1.0/debian/control
@@ -8,8 +8,8 @@ Homepage: https://github.com/raelgc/scudcloud
 
 Package: scudcloud
 Architecture: all
-Depends: ${misc:Depends}, python3, python3-pyqt4, python3-gi, python3-dbus, libunity9, gir1.2-unity-5.0
-Recommends: libqtwebkit-qupzillaplugins, fonts-lato
+Depends: ${misc:Depends}, python3, python3-pyqt4, python3-gi, python3-dbus
+Recommends: gir1.2-unity-5.0, libqtwebkit-qupzillaplugins, fonts-lato
 Description: ScudCloud is a non official desktop client for Slack
  ScudCloud is a non official desktop client for Slack.
  Slack (http://slack.com) is a platform for team communication.

--- a/scudcloud-1.0/lib/launcher.py
+++ b/scudcloud-1.0/lib/launcher.py
@@ -1,6 +1,6 @@
 from PyQt4.Qt import QApplication
 
-class Launcher:
+class DummyLauncher:
     def __init__(self, parent):
         self.parent = parent
     def set_property(self, name, value):


### PR DESCRIPTION
These changes should fix #27. I have tested that it works correctly in Debian Jessie but I don't have Ubuntu so I was not able to test whether it works when the auto-detection finds Unity (the changes are small enough that it should).

I have also moved additional packages that are not really required (Unity and font Lato) to Recommends and removed package that is indirectly required from other packages (`libunity9`).
