### PR TITLE
Add application icon to show in non-Unity appswitcher

### DIFF
--- a/scudcloud-1.0/lib/leftpane.py
+++ b/scudcloud-1.0/lib/leftpane.py
@@ -1,19 +1,21 @@
-INSTALL_DIR = "/opt/scudcloud/"
 from PyQt4 import QtWebKit, QtGui, QtCore
 from PyQt4.Qt import QApplication, QKeySequence
 from PyQt4.QtCore import QBuffer, QByteArray, QUrl, SIGNAL
 from PyQt4.QtWebKit import QWebView, QWebPage, QWebSettings
+
+from resources import get_resource_path
+
 
 class LeftPane(QWebView):
 
     def __init__(self, window):
         QWebView.__init__(self)
         self.window = window
-        with open (INSTALL_DIR+"resources/leftpane.js", "r") as f:
-             self.js=f.read()
+        with open(get_resource_path("leftpane.js"), "r") as f:
+            self.js = f.read()
         self.setFixedWidth(0)
         self.setVisible(False)
-        self.setUrl(QUrl.fromLocalFile(INSTALL_DIR+"resources/leftpane.html"))
+        self.setUrl(QUrl.fromLocalFile(get_resource_path("leftpane.html")))
         self.page().currentFrame().addToJavaScriptWindowObject("leftPane", self)
         self.page().currentFrame().evaluateJavaScript(self.js)
 

--- a/scudcloud-1.0/lib/resources.py
+++ b/scudcloud-1.0/lib/resources.py
@@ -1,0 +1,7 @@
+import os
+
+INSTALL_DIR = '/opt/scudcloud'
+
+
+def get_resource_path(filename):
+    return os.path.join(INSTALL_DIR, 'resources', filename)

--- a/scudcloud-1.0/lib/scudcloud.py
+++ b/scudcloud-1.0/lib/scudcloud.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-INSTALL_DIR = "/opt/scudcloud/"
 import sys, os
 import notify2
 from cookiejar import PersistentCookieJar
@@ -18,6 +17,9 @@ except ImportError:
     Unity = None
     Dbusmenu = None
     from launcher import DummyLauncher
+
+from resources import get_resource_path
+
 
 class ScudCloud(QtGui.QMainWindow):
 
@@ -211,7 +213,8 @@ class ScudCloud(QtGui.QMainWindow):
                 self.launcher.set_property("quicklist", ql)
 
     def notify(self, title, message):
-        notice = notify2.Notification(title, message, INSTALL_DIR+"resources/scudcloud.png")
+        notice = notify2.Notification(title, message,
+                                      get_resource_path('scudcloud.png'))
         notice.show()
         self.alert()
 

--- a/scudcloud-1.0/lib/wrapper.py
+++ b/scudcloud-1.0/lib/wrapper.py
@@ -1,9 +1,11 @@
-INSTALL_DIR = "/opt/scudcloud/"
 import sys, subprocess
 from PyQt4 import QtWebKit, QtGui, QtCore
 from PyQt4.Qt import QApplication, QKeySequence
 from PyQt4.QtCore import QBuffer, QByteArray, QUrl, SIGNAL
 from PyQt4.QtWebKit import QWebView, QWebPage, QWebSettings
+
+from resources import get_resource_path
+
 
 class Wrapper(QWebView):
 
@@ -12,8 +14,8 @@ class Wrapper(QWebView):
     def __init__(self, window):
         QWebView.__init__(self)
         self.window = window
-        with open (INSTALL_DIR+"resources/scudcloud.js", "r") as f:
-             self.js=f.read()
+        with open(get_resource_path("scudcloud.js"), "r") as f:
+            self.js = f.read()
         QWebSettings.globalSettings().setAttribute(QWebSettings.PluginsEnabled, True)
         QWebSettings.globalSettings().setAttribute(QWebSettings.JavascriptCanAccessClipboard, True)
         QWebSettings.globalSettings().setAttribute(QWebSettings.DeveloperExtrasEnabled, self.window.debug)
@@ -38,7 +40,8 @@ class Wrapper(QWebView):
         return self.page().currentFrame().evaluateJavaScript("ScudCloud."+function+"("+arg+");")
 
     def urlChanged(self, qUrl):
-        self.settings().setUserStyleSheetUrl(QUrl.fromLocalFile(INSTALL_DIR+"/resources/login.css"))
+        self.settings().setUserStyleSheetUrl(
+            QUrl.fromLocalFile(get_resource_path("login.css")))
         self.page().currentFrame().addToJavaScriptWindowObject("desktop", self)
         boot_data = self.page().currentFrame().evaluateJavaScript(self.js)
         self.window.quicklist(boot_data['channels'])

--- a/scudcloud-1.0/scudcloud
+++ b/scudcloud-1.0/scudcloud
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-import sys, argparse, os
+import sys, argparse
 INSTALL_DIR = "/opt/scudcloud/"
 sys.path.append(INSTALL_DIR+'lib')
 from PyQt4 import QtGui
 from scudcloud import ScudCloud
 from qsingleapplication import QSingleApplication
+from resources import get_resource_path
 if __name__ == "__main__":
     app = QSingleApplication(sys.argv)
     app.setApplicationName(ScudCloud.APP_NAME)
-    app.setWindowIcon(
-        QtGui.QIcon(os.path.join(INSTALL_DIR, 'resources', 'scudcloud.png')))
+    app.setWindowIcon(QtGui.QIcon(get_resource_path('scudcloud.png')))
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--debug', dest='debug', default=False, type=bool, help='enable webkit debug console (default: False)')

--- a/scudcloud-1.0/scudcloud
+++ b/scudcloud-1.0/scudcloud
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import sys, argparse
+import sys, argparse, os
 INSTALL_DIR = "/opt/scudcloud/"
 sys.path.append(INSTALL_DIR+'lib')
 from PyQt4 import QtGui
@@ -8,6 +8,8 @@ from qsingleapplication import QSingleApplication
 if __name__ == "__main__":
     app = QSingleApplication(sys.argv)
     app.setApplicationName(ScudCloud.APP_NAME)
+    app.setWindowIcon(
+        QtGui.QIcon(os.path.join(INSTALL_DIR, 'resources', 'scudcloud.png')))
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--debug', dest='debug', default=False, type=bool, help='enable webkit debug console (default: False)')


### PR DESCRIPTION
This should add application switcher icon for scudcloud.

I am not sure which icon to use though: hicolor icon theme is the same as ubuntu-mono-dark, but desktop file still uses a colorful image.
