### PR TITLE
Append messages to existing notification bubbles

### DIFF
--- a/scudcloud-1.0/lib/scudcloud.py
+++ b/scudcloud-1.0/lib/scudcloud.py
@@ -242,7 +242,10 @@ class ScudCloud(QtGui.QMainWindow):
                 self.launcher.set_property("quicklist", ql)
 
     def notify(self, title, message):
-        notice = notify2.Notification(title, message, get_resource_path('scudcloud.png'))
+        notice = notify2.Notification(title, message,
+                                      get_resource_path('scudcloud.png'))
+        # Allow appending new message to existing notification.
+        notice.set_hint_string('x-canonical-append', '')
         notice.show()
         self.alert()
 


### PR DESCRIPTION
When append is disabled notifications arrive slowly 1-by-1, now the bubble is extended when new messages arrive:
![notification](https://cloud.githubusercontent.com/assets/579798/6734897/162fa03c-ce5b-11e4-82c5-2a5ee2e745b6.png)
