### PR TITLE
TypeError in stopAlert(): Can't convert 'NoneType' object to str implicitly

### DIFF
--- a/scudcloud-1.0/debian/changelog
+++ b/scudcloud-1.0/debian/changelog
@@ -1,3 +1,9 @@
+scudcloud (1.0-22) trusty; urgency=medium
+
+  * Fixing LeftPane.stopAlert (#41)
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Mon, 23 Mar 2015 08:03:03 -0300
+
 scudcloud (1.0-21) trusty; urgency=low
 
   * Notification append(#38)

--- a/scudcloud-1.0/lib/leftpane.py
+++ b/scudcloud-1.0/lib/leftpane.py
@@ -38,7 +38,8 @@ class LeftPane(QWebView):
         self.page().currentFrame().evaluateJavaScript("LeftPane.alert('"+team+"');")
 
     def stopAlert(self, team):
-        self.page().currentFrame().evaluateJavaScript("LeftPane.stopAlert('"+team+"');")
+        if team is not None:
+            self.page().currentFrame().evaluateJavaScript("LeftPane.stopAlert('"+team+"');")
 
     @QtCore.pyqtSlot(str) 
     def switchTo(self, url):


### PR DESCRIPTION
Happens when switching accounts (have 2 accounts, 1st is open after launch, I click 2nd account, apport presents a "Crash report" and scud alerts "already started"; scud doesn't actually crash/close).

Interesting bits from apport's report:

```
CurrentDesktop: Unity
InterpreterPath: /usr/bin/python3.4
DistroRelease: Ubuntu 14.04
Package: scudcloud 1.0-21 [origin: LP-PPA-rael-gc-scudcloud]
Uname: Linux 3.13.0-46-generic x86_64
Traceback:
 Traceback (most recent call last):
   File "/opt/scudcloud/lib/wrapper.py", line 120, in count
     self.window.count()
   File "/opt/scudcloud/lib/scudcloud.py", line 262, in count
     self.leftPane.stopAlert(widget.team())
   File "/opt/scudcloud/lib/leftpane.py", line 41, in stopAlert
     self.page().currentFrame().evaluateJavaScript("LeftPane.stopAlert('"+team+"');")
 TypeError: Can't convert 'NoneType' object to str implicitly
```
