### PR TITLE
No support for SAML auth

### DIFF
--- a/scudcloud-1.0/debian/changelog
+++ b/scudcloud-1.0/debian/changelog
@@ -1,3 +1,9 @@
+scudcloud (1.0-25) trusty; urgency=medium
+
+  * SAML auth support (#44)
+
+ -- Rael Gugelmin Cunha <rael.gc@gmail.com>  Tue, 31 Mar 2015 20:35:12 -0300
+
 scudcloud (1.0-24) trusty; urgency=low
 
   * Enabling team switch at ctrl+<number> (#43)

--- a/scudcloud-1.0/lib/wrapper.py
+++ b/scudcloud-1.0/lib/wrapper.py
@@ -58,7 +58,7 @@ class Wrapper(QWebView):
         url = qUrl.toString()
         if self.window.SIGNIN_URL == url or url.endswith(".slack.com/messages?") or url.endswith(".slack.com/"):
             self.load(qUrl)
-        elif url.startswith("https://accounts.google.com/o/oauth"):
+        elif url.startswith("https://accounts.google.com/o/oauth") or url.endswith(".slack.com/sso/saml/start"):
             self.load(qUrl)
         else:
             subprocess.call(('xdg-open', url))


### PR DESCRIPTION
When given team uses SAML auth on Slack, then a page showing this is only visible:
_This team requires you to sign in with your SAML account._
and the _Sign in with SAML_ button opens new browser ourside of ScudCloud, so even after logging in outside of ScudCloud doesn't do anything as the page open inside ScudCloud (embedded into it) is not authenticated.
