### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ sudo cp $SOURCE/lib/*.py $INSTALL/lib
 sudo cp $SOURCE/resources/* $INSTALL/resources
 sudo cp $SOURCE/scudcloud $INSTALL
 sudo cp $SOURCE/LICENSE $INSTALL
-sudo cp $SOURCE/scudcloud.desktop usr/share/applications
-sudo cp $SOURCE/systray/hicolor/* usr/share/icons/hicolor/scalable/apps
+sudo cp $SOURCE/scudcloud.desktop /usr/share/applications
+sudo cp $SOURCE/systray/hicolor/* /usr/share/icons/hicolor/scalable/apps
 sudo ln -sf $INSTALL/scudcloud /usr/bin/scudcloud
 ```
 


### PR DESCRIPTION
In manual install instructions you're missing a couple of /'s before usr

sudo cp $SOURCE/scudcloud.desktop usr/share/applications
sudo cp $SOURCE/systray/hicolor/\* usr/share/icons/hicolor/scalable/apps
