### PR TITLE
Make notifications optional

### DIFF
--- a/scudcloud-1.0/lib/notifier.py
+++ b/scudcloud-1.0/lib/notifier.py
@@ -1,0 +1,48 @@
+from dbus.exceptions import DBusException
+import notify2
+
+
+class Notifier(object):
+
+    """Sends notifications via the user's notification daemon.
+
+    If the user does not have a notification daemon, it will print a notice and
+    silently cancel any passed notifications..
+    """
+
+    def __init__(self, app_name, icon):
+        """Initializes a new Notifier.
+
+        Arguments:
+        app_name --- The app name used to identify the dbus channel.
+        icon     --- The default icon to use for notifications.
+        """
+
+        self.icon = icon
+
+        try:
+            notify2.init(app_name)
+            self.enabled = True
+        except DBusException:
+            print("WARNING: No notification daemon found! "
+                  "Notifications will be ignored.")
+            self.enabled = False
+
+    def notify(self, title, message, icon=None):
+        """Sends a new notification.
+
+        Arguments:
+        title   --- The title of the notification.
+        message --- The body of the notification.
+        icon    --- The icon for the notification (defaults to self.icon).
+        """
+
+        if not self.enabled:
+            return
+
+        if icon is None:
+            icon = self.icon
+
+        notice = notify2.Notification(title, message, icon)
+        notice.set_hint_string('x-canonical-append', '')
+        notice.show()

--- a/scudcloud-1.0/lib/scudcloud.py
+++ b/scudcloud-1.0/lib/scudcloud.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import sys, os
-import notify2
 from cookiejar import PersistentCookieJar
 from leftpane import LeftPane
+from notifier import Notifier
 from systray import Systray
 from wrapper import Wrapper
 from os.path import expanduser
@@ -31,7 +31,7 @@ class ScudCloud(QtGui.QMainWindow):
     def __init__(self, parent=None):
         super(ScudCloud, self).__init__(parent)
         self.setWindowTitle('ScudCloud')
-        notify2.init(self.APP_NAME)
+        self.notifier = Notifier(self.APP_NAME, get_resource_path('scudcloud.png'))
         self.settings = QSettings(expanduser("~")+"/.scudcloud", QSettings.IniFormat)
         self.identifier = self.settings.value("Domain")
         if Unity is not None:
@@ -64,7 +64,7 @@ class ScudCloud(QtGui.QMainWindow):
         webView.show()
 
     def systray(self, show=None):
-        if show is None: 
+        if show is None:
             show = self.settings.value("Systray") == "True"
         if show:
             self.tray.show()
@@ -158,7 +158,7 @@ class ScudCloud(QtGui.QMainWindow):
         self.menus["help"]["help"].setEnabled(enabled)
 
     def createAction(self, text, slot, shortcut=None, checkable=False):
-        action = QtGui.QAction(text, self)        
+        action = QtGui.QAction(text, self)
         if shortcut is not None:
             action.setShortcut(shortcut)
         action.triggered.connect(slot)
@@ -253,11 +253,8 @@ class ScudCloud(QtGui.QMainWindow):
                         ql.child_append(item)
                 self.launcher.set_property("quicklist", ql)
 
-    def notify(self, title, message, retry=True):
-        notice = notify2.Notification(title, message, get_resource_path('scudcloud.png'))
-        # Allow appending new message to existing notification.
-        notice.set_hint_string('x-canonical-append', '')
-        notice.show()
+    def notify(self, title, message):
+        self.notifier.notify(title, message)
         self.alert()
 
     def alert(self):


### PR DESCRIPTION
This also extracts the notification functionality into its own class so as to remove the complexity from the main app.

Please note: I'm not sure that this will fix the issues that are talking about what happens when the notification daemon is killed and/or restarted. There's probably some logic to handle there about whether or not the service is available anymore, but since there isn't a reproducible issue I didn't try to tackle it here.

Fixes issue discussed in #37
