### PR TITLE
https://FOO.slack.com/archives/CHANNEL urls open in external browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 *.dsc
 *.changes
 *.upload
+
+# ignore compiled python code
+__pycache__
+*.pyc


### PR DESCRIPTION
`https://FOO.slack.com/messages/CHANNEL` are opened in scudcloud, but
`https://FOO.slack.com/archives/CHANNEL` for some reason are opened with xdg-open.
