### PR TITLE
Make the configuration file compatible with XDG

### DIFF
--- a/scudcloud-1.0/lib/scudcloud.py
+++ b/scudcloud-1.0/lib/scudcloud.py
@@ -28,11 +28,17 @@ class ScudCloud(QtGui.QMainWindow):
     forceClose = False
     messages = 0
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, settings_path=None):
         super(ScudCloud, self).__init__(parent)
         self.setWindowTitle('ScudCloud')
         self.notifier = Notifier(self.APP_NAME, get_resource_path('scudcloud.png'))
-        self.settings = QSettings(expanduser("~")+"/.scudcloud", QSettings.IniFormat)
+
+        if settings_path is None:
+            print("ERROR: Settings path not set!")
+            raise SystemExit()
+        else:
+            self.settings = QSettings(settings_path, QSettings.IniFormat)
+
         self.identifier = self.settings.value("Domain")
         if Unity is not None:
             self.launcher = Unity.LauncherEntry.get_for_desktop_id("scudcloud.desktop")

--- a/scudcloud-1.0/scudcloud
+++ b/scudcloud-1.0/scudcloud
@@ -1,21 +1,29 @@
 #!/usr/bin/env python3
-import sys, argparse
+import os
+import sys
 INSTALL_DIR = "/opt/scudcloud/"
 sys.path.append(INSTALL_DIR+'lib')
 from PyQt4 import QtGui
 from scudcloud import ScudCloud
 from qsingleapplication import QSingleApplication
 from resources import get_resource_path
-if __name__ == "__main__":
+
+# If the environment variable XDG_CONFIG_HOME is non-empty, CONFDIR is ignored
+# and the configuration directory will be $XDG_CONFIG_HOME/scudcloud instead.
+CONFDIR = '~/.config/scudcloud'
+
+
+def main():
     app = QSingleApplication(sys.argv)
     app.setApplicationName(ScudCloud.APP_NAME)
     app.setWindowIcon(QtGui.QIcon(get_resource_path('scudcloud.png')))
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '--debug', dest='debug', default=False, type=bool, help='enable webkit debug console (default: False)')
-    args = parser.parse_args()
-    ScudCloud.debug=args.debug
-    main = ScudCloud()
+
+    args = parse_arguments()
+    ScudCloud.debug = args.debug
+
+    settings_path = load_settings(args.confdir)
+
+    main = ScudCloud(settings_path=settings_path)
     app.singleStart(main, "scudcloud.pid")
     geometry = main.settings.value("geometry")
     if geometry is not None:
@@ -26,3 +34,49 @@ if __name__ == "__main__":
     else:
         main.showMaximized()
     sys.exit(app.exec_())
+
+
+def ensure_config_dir_exists(confdir):
+    from errno import EEXIST
+
+    try:
+        os.makedirs(confdir)
+    except OSError as error:
+        if error.errno != EEXIST:
+            print("This configuration directory could not be created:")
+            print(confdir)
+            raise SystemExit()
+
+    if confdir not in sys.path:
+        sys.path[0:0] = [confdir]
+
+
+def load_settings(confdir):
+    ensure_config_dir_exists(confdir)
+
+    return confdir + '/scudcloud.cfg'
+
+
+def parse_arguments():
+    from argparse import ArgumentParser
+    from os.path import expanduser
+
+    if 'XDG_CONFIG_HOME' in os.environ and os.environ['XDG_CONFIG_HOME']:
+        default_confdir = os.environ['XDG_CONFIG_HOME'] + '/scudcloud'
+    else:
+        default_confdir = CONFDIR
+
+    parser = ArgumentParser()
+    parser.add_argument('--confdir', dest='confdir',
+                        metavar='dir', default=default_confdir,
+                        help="change the configuration directory")
+    parser.add_argument('--debug', dest='debug', type=bool, default=False,
+                        help="enable webkit debug console (default: False)")
+
+    args = parser.parse_args()
+    args.confdir = expanduser(args.confdir)
+
+    return args
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The X Desktop Guidelines recommend storing application configuration in
the ~/.config/ folder. Currently Scudcloud stores its
configuration in the ~/.scudcloud file.

This adds some functionality to relocate any legacy configuration to the
new, XDG-compliant location and then loads the new location in the
application settings.

There is an API change to the `ScudCloud` class that means it will not
run using the old launcher. That is, `ScudCloud` now expects
a `settings_path` argument and will raise an error without it.

Note: This version doesn't try to move the configuration from the
original location, per feedback from @raelgc and @immerrr.

Fixes #71
Fixes #73
Fixes #75
