### PR TITLE
Add mono-[dark|light] instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ sudo cp $SOURCE/scudcloud $INSTALL
 sudo cp $SOURCE/LICENSE $INSTALL
 sudo cp $SOURCE/scudcloud.desktop /usr/share/applications
 sudo cp $SOURCE/systray/hicolor/* /usr/share/icons/hicolor/scalable/apps
+sudo cp $SOURCE/systray/mono-dark/* /usr/share/icons/mono-dark/scalable/apps
+sudo cp $SOURCE/systray/mono-light/* /usr/share/icons/mono-light/scalable/apps
 sudo ln -sf $INSTALL/scudcloud /usr/bin/scudcloud
 ```
 


### PR DESCRIPTION
In #77 the user had to install the mono-dark and mono-light icon themes
as well in order to get the system tray icons to appear correctly. They
were using Arch. Since I made the Arch package based on the README,
I hadn't included these two icon themes in the package.

I recommend adding these to the README in case a user compiled it for
his own system and has the same issue.
