### PR TITLE
Updated README.md: ensure official slack icon is readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If you want to use a Slack icon instead of ScudCloud (which is not possible to i
 ```term
 sudo dpkg-divert --add --rename --divert /opt/scudcloud/resources/scudcloud.png.real /opt/scudcloud/resources/scudcloud.png
 sudo cp ~/scudcloud.png /opt/scudcloud/resources/
+sudo chmod +r /opt/scudcloud/resources/scudcloud.png # ensure it's globally readable
 ```
 
 ## Ubuntu 12.04


### PR DESCRIPTION
Having followed over the instructions in the README to install an "official" Slack icon, I was left with `640` permission on `/opt/scudcloud/resources/scudcloud.png`. This prevent the icon from showing up.

Updated README to give instructions that ensure global read bit is set.
