### PR TITLE
Set INSTALL_DIR to be canonical path relative to 'scudcloud' script

### DIFF
--- a/scudcloud-1.0/scudcloud
+++ b/scudcloud-1.0/scudcloud
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
+from PyQt4 import QtGui
 
 def get_install_dir():
     """
@@ -9,13 +10,10 @@ def get_install_dir():
     'scudcloud' executable.  This method sets the install dir to always be
     that directory.
     """
-    return os.path.dirname(os.path.realpath(sys.argv[0]))
+    return os.path.dirname(os.path.realpath(__file__))
 
-INSTALL_DIR = get_install_dir()
-print("INSTALL_DIR is \"%s\"" % INSTALL_DIR)
-sys.path.append(INSTALL_DIR + '/lib')
-
-from PyQt4 import QtGui
+# Append the lib directory in our installation path to get remaining libraries.
+sys.path.append(os.path.join(get_install_dir(), 'lib'))
 from resources import Resources
 from scudcloud import ScudCloud
 from qsingleapplication import QSingleApplication
@@ -25,7 +23,7 @@ from qsingleapplication import QSingleApplication
 CONFDIR = '~/.config/scudcloud'
 
 def main():
-    Resources.INSTALL_DIR = INSTALL_DIR
+    Resources.INSTALL_DIR = get_install_dir()
     app = QSingleApplication(sys.argv)
     app.setApplicationName(Resources.APP_NAME)
     app.setWindowIcon(QtGui.QIcon(Resources.get_path('scudcloud.png')))

--- a/scudcloud-1.0/scudcloud
+++ b/scudcloud-1.0/scudcloud
@@ -1,8 +1,20 @@
 #!/usr/bin/env python3
 import os
 import sys
-INSTALL_DIR = "/opt/scudcloud/"
-sys.path.append(INSTALL_DIR+'lib')
+
+def get_install_dir():
+    """
+    Rather than using an inflexible value of '/opt/scudcloud', we now assume
+    that the 'lib' and 'resources' dir will be in the same directory as the
+    'scudcloud' executable.  This method sets the install dir to always be
+    that directory.
+    """
+    return os.path.dirname(os.path.realpath(sys.argv[0]))
+
+INSTALL_DIR = get_install_dir()
+print("INSTALL_DIR is \"%s\"" % INSTALL_DIR)
+sys.path.append(INSTALL_DIR + '/lib')
+
 from PyQt4 import QtGui
 from resources import Resources
 from scudcloud import ScudCloud


### PR DESCRIPTION
INSTALL_DIR was originally hardcoded to be '/opt/scudcloud'.  This
is inflexible, especially when you want to run scudcloud directly
out of the dev tree.  This change fixes that by making the dynamically
setting the INSTALL_DIR path to be the current directory that the
scudcloud main script lives.  This gets us the original behavior plus
the ability to run scudcloud out of the dev tree with ease.  It also works with
symlinks.

Tested on Fedora 22 with both normal installation and out of dev tree.
