### PR TITLE
Ported to PyQt5

### DIFF
--- a/scudcloud-1.0/default.nix
+++ b/scudcloud-1.0/default.nix
@@ -1,0 +1,6 @@
+with import <nixpkgs> {}; {
+  pyEnv = stdenv.mkDerivation {
+    name = "py";
+    buildInputs = [ stdenv python3 python3Packages.virtualenv python3Packages.pyqt5 sip ];
+  };
+}

--- a/scudcloud-1.0/lib/cookiejar.py
+++ b/scudcloud-1.0/lib/cookiejar.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from PyQt4 import QtCore, QtNetwork
+from PyQt5 import QtCore, QtNetwork
 
 class PersistentCookieJar(QtNetwork.QNetworkCookieJar):
 

--- a/scudcloud-1.0/lib/launcher.py
+++ b/scudcloud-1.0/lib/launcher.py
@@ -1,4 +1,4 @@
-from PyQt4.Qt import QApplication
+from PyQt5.Qt import QApplication
 
 class DummyLauncher:
     def __init__(self, parent):

--- a/scudcloud-1.0/lib/leftpane.py
+++ b/scudcloud-1.0/lib/leftpane.py
@@ -1,7 +1,8 @@
-from PyQt4 import QtWebKit, QtGui, QtCore
-from PyQt4.Qt import QApplication, QKeySequence
-from PyQt4.QtCore import QBuffer, QByteArray, QUrl, SIGNAL
-from PyQt4.QtWebKit import QWebView, QWebPage, QWebSettings
+from PyQt5 import QtWebKit, QtGui, QtCore
+from PyQt5.Qt import QApplication, QKeySequence
+from PyQt5.QtCore import QBuffer, QByteArray, QUrl
+from PyQt5.QtWebKit import QWebSettings
+from PyQt5.QtWebKitWidgets import QWebView, QWebPage
 from resources import Resources
 
 class LeftPane(QWebView):

--- a/scudcloud-1.0/lib/qsingleapplication.py
+++ b/scudcloud-1.0/lib/qsingleapplication.py
@@ -27,9 +27,9 @@ __email__ = "thomas.dallagnese@gmail.com"
 __version__ = "1.0"
 __URL__ = "http://www.dallagnese.fr"
 
-from PyQt4.QtGui import QMessageBox, QApplication
-from PyQt4.QtCore import QIODevice, QTimer, QCoreApplication
-from PyQt4.QtNetwork import QLocalServer, QLocalSocket
+from PyQt5.QtWidgets import QMessageBox, QApplication
+from PyQt5.QtCore import QIODevice, QTimer, QCoreApplication
+from PyQt5.QtNetwork import QLocalServer, QLocalSocket
 import sys
 
 class QSingleApplication(QApplication):

--- a/scudcloud-1.0/lib/scudcloud.py
+++ b/scudcloud-1.0/lib/scudcloud.py
@@ -8,10 +8,10 @@ from systray import Systray
 from wrapper import Wrapper
 from os.path import expanduser
 from threading import Thread
-from PyQt4 import QtCore, QtGui, QtWebKit
-from PyQt4.Qt import QApplication, QKeySequence, QTimer
-from PyQt4.QtCore import QUrl, QSettings
-from PyQt4.QtWebKit import QWebSettings
+from PyQt5 import QtCore, QtGui, QtWebKit, QtWidgets, QtWebKitWidgets
+from PyQt5.Qt import QApplication, QKeySequence, QTimer
+from PyQt5.QtCore import QUrl, QSettings
+from PyQt5.QtWebKit import QWebSettings
 
 # Auto-detection of Unity and Dbusmenu in gi repository
 try:
@@ -21,7 +21,7 @@ except ImportError:
     Dbusmenu = None
     from launcher import DummyLauncher
 
-class ScudCloud(QtGui.QMainWindow):
+class ScudCloud(QtWidgets.QMainWindow):
 
     plugins = True
     debug = False
@@ -43,10 +43,10 @@ class ScudCloud(QtGui.QMainWindow):
         self.leftPane = LeftPane(self)
         webView = Wrapper(self)
         webView.page().networkAccessManager().setCookieJar(self.cookiesjar)
-        self.stackedWidget = QtGui.QStackedWidget()
+        self.stackedWidget = QtWidgets.QStackedWidget()
         self.stackedWidget.addWidget(webView)
-        centralWidget = QtGui.QWidget(self)
-        layout = QtGui.QHBoxLayout()
+        centralWidget = QtWidgets.QWidget(self)
+        layout = QtWidgets.QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self.leftPane)
@@ -146,14 +146,14 @@ class ScudCloud(QtGui.QMainWindow):
                 "exit":        self.createAction("Quit", self.exit, QKeySequence.Quit)
             },
             "edit": {
-                "undo":        self.current().pageAction(QtWebKit.QWebPage.Undo),
-                "redo":        self.current().pageAction(QtWebKit.QWebPage.Redo),
-                "cut":         self.current().pageAction(QtWebKit.QWebPage.Cut),
-                "copy":        self.current().pageAction(QtWebKit.QWebPage.Copy),
-                "paste":       self.current().pageAction(QtWebKit.QWebPage.Paste),
-                "back":        self.current().pageAction(QtWebKit.QWebPage.Back),
-                "forward":     self.current().pageAction(QtWebKit.QWebPage.Forward),
-                "reload":      self.current().pageAction(QtWebKit.QWebPage.Reload)
+                "undo":        self.current().pageAction(QtWebKitWidgets.QWebPage.Undo),
+                "redo":        self.current().pageAction(QtWebKitWidgets.QWebPage.Redo),
+                "cut":         self.current().pageAction(QtWebKitWidgets.QWebPage.Cut),
+                "copy":        self.current().pageAction(QtWebKitWidgets.QWebPage.Copy),
+                "paste":       self.current().pageAction(QtWebKitWidgets.QWebPage.Paste),
+                "back":        self.current().pageAction(QtWebKitWidgets.QWebPage.Back),
+                "forward":     self.current().pageAction(QtWebKitWidgets.QWebPage.Forward),
+                "reload":      self.current().pageAction(QtWebKitWidgets.QWebPage.Reload)
             },
             "view": {
                 "zoomin":      self.createAction("Zoom In", self.zoomIn, QKeySequence.ZoomIn),
@@ -211,7 +211,7 @@ class ScudCloud(QtGui.QMainWindow):
         self.menus["help"]["help"].setEnabled(enabled == True)
 
     def createAction(self, text, slot, shortcut=None, checkable=False):
-        action = QtGui.QAction(text, self)
+        action = QtWidgets.QAction(text, self)
         if shortcut is not None:
             action.setShortcut(shortcut)
         action.triggered.connect(slot)
@@ -263,7 +263,7 @@ class ScudCloud(QtGui.QMainWindow):
             self.focusInEvent(event)
         if event.type() == QtCore.QEvent.KeyPress:
             # Ctrl + <n>
-            if QtGui.QApplication.keyboardModifiers() == QtCore.Qt.ControlModifier:
+            if QApplication.keyboardModifiers() == QtCore.Qt.ControlModifier:
                 if event.key() == QtCore.Qt.Key_1:   self.leftPane.click(0)
                 elif event.key() == QtCore.Qt.Key_2: self.leftPane.click(1)
                 elif event.key() == QtCore.Qt.Key_3: self.leftPane.click(2)
@@ -277,13 +277,13 @@ class ScudCloud(QtGui.QMainWindow):
                 elif event.key() == QtCore.Qt.Key_Tab: self.leftPane.clickNext(1)
   
             # ctrl + backtab
-            if (QtGui.QApplication.keyboardModifiers() & QtCore.Qt.ControlModifier) and (QtGui.QApplication.keyboardModifiers() & QtCore.Qt.ShiftModifier):
+            if (QApplication.keyboardModifiers() & QtCore.Qt.ControlModifier) and (QApplication.keyboardModifiers() & QtCore.Qt.ShiftModifier):
                 if event.key() == QtCore.Qt.Key_Backtab: self.leftPane.clickNext(-1)
                         
             # Ctrl + Shift + <key>
-            if (QtGui.QApplication.keyboardModifiers() & QtCore.Qt.ShiftModifier) and (QtGui.QApplication.keyboardModifiers() & QtCore.Qt.ShiftModifier):
+            if (QApplication.keyboardModifiers() & QtCore.Qt.ShiftModifier) and (QApplication.keyboardModifiers() & QtCore.Qt.ShiftModifier):
                 if event.key() == QtCore.Qt.Key_V: self.current().createSnippet()
-        return QtGui.QMainWindow.eventFilter(self, obj, event);
+        return QtWidgets.QMainWindow.eventFilter(self, obj, event);
 
     def focusInEvent(self, event):
         self.launcher.set_property("urgent", False)

--- a/scudcloud-1.0/lib/systray.py
+++ b/scudcloud-1.0/lib/systray.py
@@ -1,16 +1,16 @@
-from PyQt4 import QtCore, QtGui
+from PyQt5 import QtCore, QtGui, QtWidgets
 from resources import Resources
 
-class Systray(QtGui.QSystemTrayIcon):
+class Systray(QtWidgets.QSystemTrayIcon):
 
     urgent = False
 
     def __init__(self, window):
-        super(Systray, self).__init__(QtGui.QIcon.fromTheme("scudcloud"), window)
-        self.connect(self, QtCore.SIGNAL("activated(QSystemTrayIcon::ActivationReason)"), self.activatedEvent)
+        super(Systray, self).__init__(QtGui.QIcon.fromTheme("scudcloud", QtGui.QIcon("resources/scudcloud.png")), window)
+        self.activated.connect(self.activatedEvent)
         self.window = window
         self.setToolTip(Resources.APP_NAME)
-        self.menu = QtGui.QMenu(self.window)
+        self.menu = QtWidgets.QMenu(self.window)
         self.menu.addAction('Show', self.restore)
         self.menu.addSeparator()
         self.menu.addAction(self.window.menus["file"]["preferences"])
@@ -22,29 +22,29 @@ class Systray(QtGui.QSystemTrayIcon):
     def alert(self):
         if not self.urgent:
             self.urgent = True
-            self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention"))
+            self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention", QtGui.QIcon("systray/hicolor/scudcloud-attention.svg")))
 
     def stopAlert(self):
         self.urgent = False
-        self.setIcon(QtGui.QIcon.fromTheme("scudcloud"))
+        self.setIcon(QtGui.QIcon.fromTheme("scudcloud", QtGui.QIcon("systray/hicolor/scudcloud.svg")))
 
     def setCounter(self, i):
         if 0 == i:
             if True == self.urgent:
-                self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention"))
+                self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention", QtGui.QIcon("systray/hicolor/scudcloud-attention.svg")))
             else:
-                self.setIcon(QtGui.QIcon.fromTheme("scudcloud"))
+                self.setIcon(QtGui.QIcon.fromTheme("scudcloud", QtGui.QIcon("systray/hicolor/scudcloud.svg")))
         elif i > 0 and i < 10:
-            self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention-"+str(int(i))))
+            self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention-" + str(int(i)), QtGui.QIcon("systray/hicolor/scudcloud-attention-" + str(int(i)) + ".svg")))
         elif i > 9:
-            self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention-9-plus"))
+            self.setIcon(QtGui.QIcon.fromTheme("scudcloud-attention-9-plus", QtGui.QIcon("systray/hicolor/scudcloud-9-plus.svg")))
 
     def restore(self):
         self.window.show()
         self.stopAlert()
 
     def activatedEvent(self, reason):
-        if reason in [QtGui.QSystemTrayIcon.MiddleClick, QtGui.QSystemTrayIcon.Trigger]:
+        if reason in [QtWidgets.QSystemTrayIcon.MiddleClick, QtWidgets.QSystemTrayIcon.Trigger]:
             if self.window.isHidden() or self.window.isMinimized() or not self.window.isActiveWindow():
                 self.restore()
             else:

--- a/scudcloud-1.0/scudcloud
+++ b/scudcloud-1.0/scudcloud
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import os
 import sys
-from PyQt4 import QtGui
+from PyQt5 import QtGui
 
 def get_install_dir():
     """


### PR DESCRIPTION
I use NixOS. After creating a Nix derivation (a.k.a package), the PyQt4/webkit versions just wouldn't work without a lot of effort due to other library issues with the NixOS version I'm using. So I ported the project to PyQt5 which uses a newer webkit  and it's working great for me. The systray functionality has some issues on NixOS using the theme-based access to QIcon's, but I wasn't sure if that was a Qt5 thing or specific to my install. So, that's why the systray code has the alternative relative paths for QIcon bits.

Anyway, if this PR is useful here it is as a starting point for some testing on other platforms. 
