### PR TITLE
Allow the menubar to be hidden

### DIFF
--- a/scudcloud-1.0/lib/scudcloud.py
+++ b/scudcloud-1.0/lib/scudcloud.py
@@ -227,10 +227,9 @@ class ScudCloud(QtGui.QMainWindow):
 
     def createAction(self, text, slot, shortcut=None, checkable=False):
         action = QtGui.QAction(text, self)
-        if shortcut is not None:
-            action.setShortcut(shortcut)
         action.triggered.connect(slot)
         if shortcut is not None:
+            action.setShortcut(shortcut)
             self.addAction(action)
         if checkable:
             action.setCheckable(True)

--- a/scudcloud-1.0/lib/scudcloud.py
+++ b/scudcloud-1.0/lib/scudcloud.py
@@ -208,7 +208,8 @@ class ScudCloud(QtGui.QMainWindow):
         viewMenu.addAction(self.menus["view"]["reset"])
         viewMenu.addSeparator()
         viewMenu.addAction(self.menus["view"]["fullscreen"])
-        viewMenu.addAction(self.menus["view"]["hidemenu"])
+        if Unity is None:
+            viewMenu.addAction(self.menus["view"]["hidemenu"])
         helpMenu = menu.addMenu("&Help")
         helpMenu.addAction(self.menus["help"]["help"])
         helpMenu.addAction(self.menus["help"]["center"])

--- a/scudcloud-1.0/lib/scudcloud.py
+++ b/scudcloud-1.0/lib/scudcloud.py
@@ -102,10 +102,7 @@ class ScudCloud(QtGui.QMainWindow):
 
     def toggleMenuBar(self):
         menu = self.menuBar()
-        if menu.isHidden():
-            menu.show()
-        else:
-            menu.hide()
+        menu.setVisible(menu.isHidden())
 
     def restore(self):
         geometry = self.settings.value("geometry")

--- a/scudcloud-1.0/lib/scudcloud.py
+++ b/scudcloud-1.0/lib/scudcloud.py
@@ -100,6 +100,13 @@ class ScudCloud(QtGui.QMainWindow):
         else:
             self.showFullScreen()
 
+    def toggleMenuBar(self):
+        menu = self.menuBar()
+        if menu.isHidden():
+            menu.show()
+        else:
+            menu.hide()
+
     def restore(self):
         geometry = self.settings.value("geometry")
         if geometry is not None:
@@ -168,7 +175,8 @@ class ScudCloud(QtGui.QMainWindow):
                 "zoomin":      self.createAction("Zoom In", self.zoomIn, QKeySequence.ZoomIn),
                 "zoomout":     self.createAction("Zoom Out", self.zoomOut, QKeySequence.ZoomOut),
                 "reset":       self.createAction("Reset", self.zoomReset, QtCore.Qt.CTRL + QtCore.Qt.Key_0),
-                "fullscreen":  self.createAction("Toggle Full Screen", self.toggleFullScreen, QtCore.Qt.Key_F11)        
+                "fullscreen":  self.createAction("Toggle Full Screen", self.toggleFullScreen, QtCore.Qt.Key_F11),
+                "hidemenu":    self.createAction("Toggle Menubar", self.toggleMenuBar, QtCore.Qt.Key_F12)
             },
             "help": {
                 "help":       self.createAction("Help and Feedback", lambda : self.current().help(), QKeySequence.HelpContents),
@@ -203,6 +211,7 @@ class ScudCloud(QtGui.QMainWindow):
         viewMenu.addAction(self.menus["view"]["reset"])
         viewMenu.addSeparator()
         viewMenu.addAction(self.menus["view"]["fullscreen"])
+        viewMenu.addAction(self.menus["view"]["hidemenu"])
         helpMenu = menu.addMenu("&Help")
         helpMenu.addAction(self.menus["help"]["help"])
         helpMenu.addAction(self.menus["help"]["center"])
@@ -224,6 +233,8 @@ class ScudCloud(QtGui.QMainWindow):
         if shortcut is not None:
             action.setShortcut(shortcut)
         action.triggered.connect(slot)
+        if shortcut is not None:
+            self.addAction(action)
         if checkable:
             action.setCheckable(True)
         return action

--- a/scudcloud-1.0/lib/systray.py
+++ b/scudcloud-1.0/lib/systray.py
@@ -1,5 +1,6 @@
 from PyQt4 import QtCore, QtGui
 from resources import Resources
+import scudcloud 
 
 class Systray(QtGui.QSystemTrayIcon):
 
@@ -12,7 +13,8 @@ class Systray(QtGui.QSystemTrayIcon):
         self.setToolTip(Resources.APP_NAME)
         self.menu = QtGui.QMenu(self.window)
         self.menu.addAction('Show', self.restore)
-        self.menu.addAction('Toggle Menubar', self.toggleMenuBar)
+        if scudcloud.Unity is None:
+            self.menu.addAction('Toggle Menubar', self.toggleMenuBar)
         self.menu.addSeparator()
         self.menu.addAction(self.window.menus["file"]["preferences"])
         self.menu.addAction(self.window.menus["help"]["about"])

--- a/scudcloud-1.0/lib/systray.py
+++ b/scudcloud-1.0/lib/systray.py
@@ -12,6 +12,7 @@ class Systray(QtGui.QSystemTrayIcon):
         self.setToolTip(Resources.APP_NAME)
         self.menu = QtGui.QMenu(self.window)
         self.menu.addAction('Show', self.restore)
+        self.menu.addAction('Toggle Menubar', self.toggleMenuBar)
         self.menu.addSeparator()
         self.menu.addAction(self.window.menus["file"]["preferences"])
         self.menu.addAction(self.window.menus["help"]["about"])
@@ -42,6 +43,9 @@ class Systray(QtGui.QSystemTrayIcon):
     def restore(self):
         self.window.show()
         self.stopAlert()
+
+    def toggleMenuBar(self):
+        self.window.toggleMenuBar()
 
     def activatedEvent(self, reason):
         if reason in [QtGui.QSystemTrayIcon.MiddleClick, QtGui.QSystemTrayIcon.Trigger]:


### PR DESCRIPTION
On systems without unity, the menubar might look very ugly compared to
the rest of the app, so we provide the option to hide it.

We also need to register all menubar actions with shortcuts on the
mainmenu, because actions of hidden widgets do not trigger.

In case someone does not remember the shortcut, the systray also allows
toggling of the menubar.
