### PR TITLE
fix dictionary path check

### DIFF
--- a/scudcloud-1.0/lib/speller.py
+++ b/scudcloud-1.0/lib/speller.py
@@ -24,7 +24,7 @@ class Speller(QObject):
             return
         dictionaryPath = self.getDictionaryPath()
         language = self.parseLanguage(dictionaryPath)
-        if dictionaryPath is None or language is None:
+        if dictionaryPath=='' or language is None:
             return
         self.hunspell = hunspell.HunSpell(dictionaryPath + ".dic", dictionaryPath + ".aff")
         self.initialized = True

--- a/scudcloud-1.0/lib/speller.py
+++ b/scudcloud-1.0/lib/speller.py
@@ -24,7 +24,7 @@ class Speller(QObject):
             return
         dictionaryPath = self.getDictionaryPath()
         language = self.parseLanguage(dictionaryPath)
-        if dictionaryPath=='' or language is None:
+        if not dictionaryPath or language is None:
             return
         self.hunspell = hunspell.HunSpell(dictionaryPath + ".dic", dictionaryPath + ".aff")
         self.initialized = True


### PR DESCRIPTION
`getDictionaryPath()` returns `''` when nothing is found and not `None`
