### PR TITLE
Fix QuotaExceededError

### DIFF
--- a/scudcloud-1.1/lib/scudcloud.py
+++ b/scudcloud-1.1/lib/scudcloud.py
@@ -79,7 +79,7 @@ class ScudCloud(QtGui.QMainWindow):
         # We don't want Java
         QWebSettings.globalSettings().setAttribute(QWebSettings.JavaEnabled, False)
         # We don't need History
-        QWebSettings.globalSettings().setAttribute(QWebSettings.PrivateBrowsingEnabled, True)
+        QWebSettings.globalSettings().setAttribute(QWebSettings.PrivateBrowsingEnabled, False)
         # Enabling Local Storage (now required by Slack)
         QWebSettings.globalSettings().setAttribute(QWebSettings.LocalStorageEnabled, True)
         # Enabling Cache


### PR DESCRIPTION
Fixes the localstorage error causing #294:
`QuotaExceededError: DOM Exception 22: An attempt was made to add something to storage that exceeded the quota.`

by setting QWebSettings.PrivateBrowsingEnabled to False(thus enabling local storage)
