### PR TITLE
Remove #!/usr/bin/env in non main libs

### DIFF
--- a/scudcloud-1.1/lib/cookiejar.py
+++ b/scudcloud-1.1/lib/cookiejar.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from PyQt4 import QtCore, QtNetwork
 
 class PersistentCookieJar(QtNetwork.QNetworkCookieJar):

--- a/scudcloud-1.1/lib/scudcloud.py
+++ b/scudcloud-1.1/lib/scudcloud.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import sys, os, time
 from cookiejar import PersistentCookieJar
 from leftpane import LeftPane

--- a/scudcloud-1.1/scudcloud.desktop
+++ b/scudcloud-1.1/scudcloud.desktop
@@ -1,4 +1,3 @@
-#!/usr/bin/env xdg-open
 [Desktop Entry]
 Version=1.0
 Terminal=false


### PR DESCRIPTION
Several of the python files have headers for the environment.  When these
files are packaged, they are packaged in mode 0644 since they are not
intended to be executed directly.  rpmlint for Fedora complains when these
headers are present in files that aren't marked as executable.  Hence this patch
removes them.
