### PR TITLE
Fix decodeAndCopy if there's no redirection in URL

### DIFF
--- a/scudcloud-1.1/lib/wrapper.py
+++ b/scudcloud-1.1/lib/wrapper.py
@@ -83,7 +83,10 @@ class Wrapper(QWebView):
         menu.exec_(event.globalPos())
 
     def decodeAndCopy(self, url):
-        param, value = url.split("=",1)
+        if url.startswith("https://slack-redir.net/link?url="):
+            param, value = url.split("=",1)
+        else:
+            value = url
         decodedURL = unquote(value)
         QApplication.clipboard().setText(decodedURL)
 

--- a/scudcloud-1.1/lib/wrapper.py
+++ b/scudcloud-1.1/lib/wrapper.py
@@ -85,9 +85,9 @@ class Wrapper(QWebView):
     def decodeAndCopy(self, url):
         if url.startswith("https://slack-redir.net/link?url="):
             param, value = url.split("=",1)
+            decodedURL = unquote(value)
         else:
-            value = url
-        decodedURL = unquote(value)
+            decodedURL = url
         QApplication.clipboard().setText(decodedURL)
 
     def call(self, function, arg=None):


### PR DESCRIPTION
At least on Ubuntu-14.04 Slack provides URLs without redirection
("https://slack-redir.net/link?url="). Not sure about other OSes.
So let's make a conditional and split URL only if we find redirect
in it.

Closes: #321
