### PR TITLE
Exit application on request by session manager

### DIFF
--- a/scudcloud-1.1/lib/scudcloud.py
+++ b/scudcloud-1.1/lib/scudcloud.py
@@ -310,6 +310,9 @@ class ScudCloud(QtGui.QMainWindow):
     def titleChanged(self):
         self.setWindowTitle(self.current().title())
 
+    def setForceClose(self):
+        self.forceClose = True
+
     def closeEvent(self, event):
         if not self.forceClose and self.settings.value("Systray") == "True":
             self.hide()
@@ -322,6 +325,7 @@ class ScudCloud(QtGui.QMainWindow):
             qUrl = self.stackedWidget.widget(0).url()
             if self.identifier is None and Resources.MESSAGES_URL_RE.match(qUrl.toString()):
                 self.settings.setValue("Domain", 'https://'+qUrl.host())
+        self.forceClose = False
 
     def show(self):
         self.setWindowState(self.windowState() & ~QtCore.Qt.WindowMinimized | QtCore.Qt.WindowActive)
@@ -329,7 +333,7 @@ class ScudCloud(QtGui.QMainWindow):
         self.setVisible(True)
 
     def exit(self):
-        self.forceClose = True
+        self.setForceClose()
         self.close()
 
     def quicklist(self, channels):

--- a/scudcloud-1.1/scudcloud
+++ b/scudcloud-1.1/scudcloud
@@ -39,6 +39,7 @@ def main():
         print("Configuration directory "+args.confdir+" could not be created! Exiting...")
         raise SystemExit()
     win = ScudCloud(settings_path=settings_path)
+    app.commitDataRequest.connect(win.setForceClose, type=QtCore.Qt.DirectConnection)
     server = QLocalServer()
     server.newConnection.connect(restore)
     server.listen(appKey)


### PR DESCRIPTION
Set forceClose to True when commitDataRequest was emitted. This
will stop the application from canceling shutdown/logout requests.

From http://doc.qt.io/qt-4.8/qapplication.html#commitDataRequest
"commitDataRequest is emitted when the QSessionManager wants the
application to commit all its data."

Fixes #314

Negative side effect: When the signal was emitted once, the next
closeEvent will close the application regardless of the "Close to
Tray" setting. Maybe someone comes up with an idea how to fix that.
