### PR TITLE
Fix URL fragments in copied links

### DIFF
--- a/scudcloud-1.1/lib/wrapper.py
+++ b/scudcloud-1.1/lib/wrapper.py
@@ -61,19 +61,21 @@ class Wrapper(QWebView):
             if hit.isContentEditable() and not hit.isContentSelected() and element.attribute("type") != "password":
                 self.window.speller.populateContextMenu(menu, element)
         pageMenu = self.page().createStandardContextMenu()
-        url = hit.linkUrl()        
+        url = hit.linkUrl()
         if pageMenu is not None:
             for a in pageMenu.actions():
                 if 'Open Link' == a.text() and not url.isEmpty():
                     action = QtGui.QAction('Open Link', self)
-                    action.triggered.connect(lambda: self.systemOpen(url.toString()))
+                    action.triggered.connect(lambda: self.systemOpen(
+                        self._urlToString(url)))
                     menu.addAction(action)
                 elif a.text() in entriesToHide:
                     continue
                 # Let's skip Slack redirect engine only when copying the link (Fixes #42)
                 elif 'Copy Link' == a.text() and not url.isEmpty():
                     action = QtGui.QAction('Copy Link', self)
-                    action.triggered.connect(lambda: self.decodeAndCopy(url.toString()))
+                    action.triggered.connect(lambda: self.decodeAndCopy(
+                        self._urlToString(url)))
                     menu.addAction(action)
                 elif a.isSeparator():
                     menu.addSeparator()
@@ -107,6 +109,11 @@ class Wrapper(QWebView):
         if Resources.SERVICES_URL_RE.match(url):
             self.systemOpen(url)
             self.load(QUrl("https://"+qUrl.host()+"/messages/general"))
+
+    @staticmethod
+    def _urlToString(url):
+        """Convert QUrl to str preserving encoding of special characters."""
+        return bytes(url.toEncoded()).decode('latin1')
 
     def _loadFinished(self, ok=True):
         # Starting the webkit-JS bridge


### PR DESCRIPTION
This PR fixes a subtle issue that reveals itself when copying links that contain URL fragments, e.g. `https://example.com/foo/bar#baz`. The redirection link looks like

```
https://slack-redir.net/link?url=http%3A%2F%2Fexample.com%2Ffoo%2Fbar%23qux&v=3
```

but `url.toString()` loses the percent-encoding making it 

```
https://slack-redir.net/link?url=http://example.com/foo/bar#qux&v=3
```

and that is incorrectly parsed to

```
SplitResult(
    scheme='https',
    netloc='slack-redir.net',
    path='/link',
    query='url=http://example.com/foo/bar',
    fragment='qux&v=3')
```

In Qt5 one can use [formatting flags](http://doc.qt.io/qt-5/qurl.html#ComponentFormattingOption-enum) to preserve encoding in `toString`, but Qt4 does not support those, so I had to use `toEncoded` and convert it from bytearray manually.
