### PR TITLE
Adding `python3-setuptools` as requirement for manual install (#402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ There are repositories available for these distributions. All you need to do is 
 
 The manual install is intended for not supported distros (if you want to contribute with a package for your distro, you're welcome!).
 
-First, you'll need to install at least packages for `python3`, `python-qt4` (`qt4` for `python3`) and `python-dbus` (`dbus` library for `python3`).
+First, you'll need to install at least packages for `python3`, `python3-setuptools`, `python-qt4` (`qt4` for `python3`) and `python-dbus` (`dbus` library for `python3`).
 
 Then run the following steps:
 


### PR DESCRIPTION
Fixes #402
