### PR TITLE
Add --urgent-hint CLI option for window manager notifications

### DIFF
--- a/scudcloud/__main__.py
+++ b/scudcloud/__main__.py
@@ -49,8 +49,9 @@ def main():
               " could not be created! Exiting...")
         raise SystemExit()
     minimized = True if args.minimized is True else None
+    urgent_hint = True if args.urgent_hint is True else None
 
-    win = sca.ScudCloud(debug=args.debug, minimized=minimized, settings_path=settings_path)
+    win = sca.ScudCloud(debug=args.debug, minimized=minimized, urgent_hint=urgent_hint, settings_path=settings_path)
     app.commitDataRequest.connect(win.setForceClose, type=QtCore.Qt.DirectConnection)
 
     server = QLocalServer()
@@ -87,6 +88,7 @@ def parse_arguments():
     parser.add_argument('--confdir',    dest='confdir',      metavar='dir', default=default_confdir, help="change the configuration directory")
     parser.add_argument('--debug',      dest='debug',        type=bool,     default=False,           help="enable webkit debug console (default: False)")
     parser.add_argument('--minimized',  dest='minimized',    type=bool,     default=False,           help="start minimized to tray (default: False)")
+    parser.add_argument('--urgent-hint',dest='urgent_hint',  type=bool,     default=False,           help="set window manager URGENT hint( default: False)")
     parser.add_argument('--version',    action="store_true",                                         help="print version and exit")
     args = parser.parse_args()
     if args.version:

--- a/scudcloud/scudcloud.py
+++ b/scudcloud/scudcloud.py
@@ -37,10 +37,11 @@ class ScudCloud(QtGui.QMainWindow):
     speller = Speller()
     title = 'ScudCloud'
 
-    def __init__(self, debug = False, parent = None, minimized = None, settings_path = ""):
+    def __init__(self, debug = False, parent = None, minimized = None, urgent_hint = None, settings_path = ""):
         super(ScudCloud, self).__init__(parent)
         self.debug = debug
         self.minimized = minimized
+        self.urgent_hint = urgent_hint
         self.setWindowTitle(self.title)
         self.settings_path = settings_path
         self.notifier = Notifier(Resources.APP_NAME, Resources.get_path('scudcloud.png'))
@@ -426,6 +427,8 @@ class ScudCloud(QtGui.QMainWindow):
         if not self.isActiveWindow():
             self.launcher.set_property("urgent", True)
             self.tray.alert()
+        if self.urgent_hint is True:
+            QApplication.alert(self)
 
     def count(self):
         total = 0


### PR DESCRIPTION
On X11, some window managers use the URGENCY bit in WM_HINTS to notify
the user when a window needs attention.  However, not all window
manager behave this way.

This patch adds a CLI option to scudcloud to enable setting the
URGENCY bit whenever scudcloud sends a notification:

  --urgent-hint URGENT_HINT
                        set window manager URGENT hint( default: False)

Users who want to use the URGENT hint for notifications can launch
scudcloud with the --urgent-hint argument.

Testing:

I verified this is working as expected on Ubuntu 16.04 with the xmonad
window manager.

Closes: #401
Signed-off-by: Curt Brune curt@brune.net
