### PR TITLE
Add option to change dictionary for Hunspell

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sudo apt-get install scudcloud
 
 If you want **spell checking**, add the `hunspell` dictionary for your language and make sure dependencies are installed. For `en-us`:
 
-    sudo apt-get install hunspell-en-us python3-hunspell
+    sudo apt-get install hunspell-en-us libqtwebkit-qupzillaplugins python3-hunspell
 
 If you want to use a Slack icon instead of ScudCloud (which is not possible to include in this package due to copyright), download [any 128px Slack icon](https://www.google.com.br/search?q=slack+icon&tbm=isch&source=lnt&tbs=isz:ex,iszw:128,iszh:128) to your home folder saving as `scudcloud.png` and run:
 
@@ -132,6 +132,7 @@ If not listed above, you're welcome [to contribute](/CONTRIBUTING.md). In this m
 
 Make sure you have the following packages installed:
 
+* `libqtwebkit-qupzillaplugins`
 * `python3-hunspell`
 * `hunspell-en-us`
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sudo apt-get install scudcloud
 
 If you want **spell checking**, add the `hunspell` dictionary for your language and make sure dependencies are installed. For `en-us`:
 
-    sudo apt-get install hunspell-en-us libqtwebkit-qupzillaplugins python3-hunspell
+    sudo apt-get install hunspell-en-us python3-hunspell
 
 If you want to use a Slack icon instead of ScudCloud (which is not possible to include in this package due to copyright), download [any 128px Slack icon](https://www.google.com.br/search?q=slack+icon&tbm=isch&source=lnt&tbs=isz:ex,iszw:128,iszh:128) to your home folder saving as `scudcloud.png` and run:
 
@@ -132,7 +132,6 @@ If not listed above, you're welcome [to contribute](/CONTRIBUTING.md). In this m
 
 Make sure you have the following packages installed:
 
-* `libqtwebkit-qupzillaplugins`
 * `python3-hunspell`
 * `hunspell-en-us`
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ Make sure you have the following packages installed:
 * `python3-hunspell`
 * `hunspell-en-us`
 
+Hunspell uses your system locale to determine the correct language to use.
+
+You can overwrite this by setting variable Hunspell in the config file:
+
+    ~/.config/scudcloud/scudcloud.cfg
+
+e.g.
+    Hunspell=en_US
+
+This can be useful if there isn't a hunspell package available for your locale.
+
 #### 4. `Keep me signed in` is not working / My team is not saved
 
 For some reason, ScudCloud was not able to create the configuration folder. Please, manually create this folder:

--- a/scudcloud/scudcloud.py
+++ b/scudcloud/scudcloud.py
@@ -34,7 +34,6 @@ class ScudCloud(QtGui.QMainWindow):
 
     forceClose = False
     messages = 0
-    speller = Speller()
     title = 'ScudCloud'
 
     def __init__(self, debug = False, parent = None, minimized = None, urgent_hint = None, settings_path = ""):
@@ -48,6 +47,7 @@ class ScudCloud(QtGui.QMainWindow):
         self.settings = QSettings(self.settings_path + '/scudcloud.cfg', QSettings.IniFormat)
         self.notifier.enabled = self.settings.value('Notifications', defaultValue=True, type=bool)
         self.identifier = self.settings.value("Domain")
+        self.speller = Speller(self.settings.value("Hunspell"))
         if Unity is not None:
             self.launcher = Unity.LauncherEntry.get_for_desktop_id("scudcloud.desktop")
         else:

--- a/scudcloud/speller.py
+++ b/scudcloud/speller.py
@@ -19,10 +19,14 @@ class Speller(QObject):
     initialized = False
     startPos = 0
 
-    def __init__(self):
+    def __init__(self, lang=None):
         super(Speller, self).__init__()
         if self.initialized or hunspell.HunSpell is None:
             return
+        if lang:
+            self.lang = lang
+        else:
+            self.lang = QLocale.system().name()
         dictionaryPath = self.getDictionaryPath()
         language = self.parseLanguage(dictionaryPath)
         if not dictionaryPath or language is None:
@@ -46,7 +50,7 @@ class Speller(QObject):
         return QFile(path + ".dic").exists() and QFile(path + ".aff").exists();
 
     def getDictionaryPath(self):
-        dicPath = Resources.SPELL_DICT_PATH + QLocale.system().name()
+        dicPath = Resources.SPELL_DICT_PATH + self.lang
         if self.dictionaryExists(dicPath):
             return dicPath
         return ''


### PR DESCRIPTION
On my system, my language is set to en_IE.

This is the dictionary that hunspell looks for, but there isn't a hunspell package for en_IE.

Added an option to scudcloud.cfg so you can overwrite this.
e.g.
Hunspell=en_GB
