### PR TITLE
Updated install info to work with debian derivatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,21 @@ sudo apt-get update
 sudo apt-get upgrade
 ```
 
-## Debian
+## Debian and derivatives like BunsenLabs Linux
 
-Make sure `software-properties-common` is installed, then run:
+Make sure the `software-properties-common` and `lsb-release` packages are installed, then run:
 
 ```
 sudo apt-add-repository -y ppa:rael-gc/scudcloud
-sudo sed -i 's/jessie/trusty/g' /etc/apt/sources.list.d/rael-gc-scudcloud-jessie.list
+DISTRIB_CODENAME=$(lsb_release -sc)
+sudo sed -i "s/${DISTRIB_CODENAME}/trusty/g" /etc/apt/sources.list.d/rael-gc-scudcloud-${DISTRIB_CODENAME}.list
 sudo apt-get update
 sudo apt-get install scudcloud
+```
+
+If you want spell checking and a Slack icon, follow related instructions on [Ubuntu Install section](#ubuntukubuntu-and-mint).
+
+### 
 ```
 
 If you want spell checking and a Slack icon, follow related instructions on [Ubuntu Install section](#ubuntukubuntu-and-mint).


### PR DESCRIPTION
Updated the README instructions for debian to include derivatives such as BunsenLabs linux