### PR TITLE
Don't crash if the notification library returns an exception

### DIFF
--- a/scudcloud/notifier.py
+++ b/scudcloud/notifier.py
@@ -32,4 +32,7 @@ class Notifier(object):
         else:
             notice = notify2.Notification(title, message, icon)
         notice.set_hint_string('x-canonical-append', '')
-        notice.show()
+        try:
+            notice.show()
+        except:
+            pass


### PR DESCRIPTION
Fixes #528.