### PR TITLE
Work around issues with gi

### DIFF
--- a/scudcloud/notifier.py
+++ b/scudcloud/notifier.py
@@ -3,7 +3,7 @@ try:
     import gi
     gi.require_version('Notify', '0.7')
     from gi.repository import Notify
-except ImportError:
+except (ImportError, AttributeError):
     from scudcloud import notify2
     Notify = None
 

--- a/scudcloud/scudcloud.py
+++ b/scudcloud/scudcloud.py
@@ -28,7 +28,7 @@ try:
     import gi
     gi.require_version('Unity', '7.0')
     from gi.repository import Unity, Dbusmenu
-except (ImportError, ValueError):
+except (ImportError, ValueError, AttributeError):
     Unity = None
     Dbusmenu = None
     from scudcloud.launcher import DummyLauncher


### PR DESCRIPTION
Running `scudcloud` was producing errors from the `gi` package, claiming that `require_version` does not exist. This change adjusts the `try` blocks to catch `AttributeError`s, allowing ScudCloud to continue to work despite issues with `gi`.