### PR TITLE
Allow ValueError as a notify exception

### DIFF
--- a/scudcloud/notifier.py
+++ b/scudcloud/notifier.py
@@ -3,7 +3,7 @@ try:
     import gi
     gi.require_version('Notify', '0.7')
     from gi.repository import Notify
-except (ImportError, AttributeError):
+except (ImportError, AttributeError, ValueError):
     from scudcloud import notify2
     Notify = None
 


### PR DESCRIPTION
I was getting this:

<pre>
averagest% python3 -m scudcloud            
Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/w/apps/exp/scudcloud/scudcloud/__main__.py", line 16, in <module>
    import scudcloud.scudcloud as sca
  File "/home/w/apps/exp/scudcloud/scudcloud/scudcloud.py", line 3, in <module>
    from scudcloud.notifier import Notifier
  File "/home/w/apps/exp/scudcloud/scudcloud/notifier.py", line 4, in <module>
    gi.require_version('Notify', '0.7')
  File "/usr/lib/python3/dist-packages/gi/__init__.py", line 130, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Notify not available
</pre>

Adding ValueError to the list of allowed exceptions made the program start.